### PR TITLE
[feature] [command] Stats (gets meme count of a user)

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -2,6 +2,7 @@ mod age;
 mod register;
 mod coinflip;
 mod memeroll;
+mod stats;
 use poise::serenity_prelude::ChannelId;
 use poise::serenity_prelude::Message;
 
@@ -9,6 +10,7 @@ pub use self::age::*;
 pub use self::register::*;
 pub use self::coinflip::*;
 pub use self::memeroll::*;
+pub use self::stats::*;
 
 // User data, which is stored and accessible in all command invocations
 pub struct Data {

--- a/src/commands/stats.rs
+++ b/src/commands/stats.rs
@@ -24,6 +24,9 @@ pub async fn stats(
         ctx.say(format!("> **Meme count**\n> {}: {} memes posted", u, meme_message_count)).await?;
         return Ok(());
     } else {
+        // TODO: When we have a database, post a leaderboard of the top 10 users in addition to the author
+        let meme_message_count = get_meme_count(&ctx.author(), &ctx.data().meme_msgs);
+        ctx.say(format!("> **Meme count**\n> {}: {} memes posted", ctx.author(), meme_message_count)).await?;
         return Ok(()); 
     }
 }

--- a/src/commands/stats.rs
+++ b/src/commands/stats.rs
@@ -1,0 +1,29 @@
+use poise::serenity_prelude as serenity;
+use crate::commands::{Context, Error};
+
+// TODO: This is a hacky way to get the number of memes a user has posted
+// Instead, we should be storing this data in a database, and updating every time a meme is posted
+fn get_meme_count(user: &serenity::User, meme_messages: &Vec<serenity::Message>) -> u32 {
+    let mut meme_message_count = 0;
+    for message in meme_messages.iter() {
+        if message.author.id == user.id {
+            meme_message_count += 1;
+        }
+    }
+    meme_message_count
+}
+
+/// Posts a meme randomly from #image_post_memes
+#[poise::command(slash_command, prefix_command)]
+pub async fn stats(
+    ctx: Context<'_>,
+    #[description = "Selected user"] user: Option<serenity::User>,
+) -> Result<(), Error> {
+    if let Some(u) = user.as_ref() {
+        let meme_message_count = get_meme_count(u, &ctx.data().meme_msgs);
+        ctx.say(format!("> **Meme count**\n> {}: {} memes posted", u, meme_message_count)).await?;
+        return Ok(());
+    } else {
+        return Ok(()); 
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,7 @@ async fn main() {
               commands::age(),
               commands::register(),
               commands::coinflip(),
+              commands::stats(),
               ],
             ..Default::default()
         })


### PR DESCRIPTION
`/stats <optional user>`
Gets the meme count of a user
If no user is provided, it gets the meme count of the author

This assumes that the `meme_msgs` list is filled, which as of this PR, is not.